### PR TITLE
Refine calculator UI to match reference layout

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -39,14 +39,19 @@
 /* right panel layout */
 .creo-right{display:flex;flex-direction:column;gap:20px}
 .creo-row{display:grid;gap:20px}
+.creo-row.is-empty{display:none}
 .row-one{grid-template-columns:1.5fr 1fr}
 .row-two{grid-template-columns:1fr 1fr}
 @media (max-width:1100px){.row-one,.row-two{grid-template-columns:1fr}}
 
 /* cards */
 .creo-card{background:#fff;border:1px solid #e5e7eb;border-radius:14px;padding:16px}
+.creo-card.info-card{background:#f8fafc;border-color:#e2e8f0}
 .creo-card-h{display:flex;align-items:center;justify-content:space-between;margin-bottom:12px}
 .creo-card-h h3{margin:0;font-size:15px}
+.creo-card-copy{margin:0 0 12px;font-size:13px;line-height:1.5;color:#475569}
+.creo-card.summary-card .creo-summary{font-size:13px;line-height:1.6;color:#475569}
+.creo-card.summary-card .creo-summary strong{color:#0f172a}
 .rightcol{display:grid;grid-template-rows:auto auto;gap:20px}
 
 /* KPI tiles */
@@ -84,6 +89,20 @@
 .range input[type=range]::-webkit-slider-thumb{appearance:none;margin-top:-6px;width:18px;height:18px;border-radius:50%;background:#111827;border:2px solid #fff;box-shadow:0 0 0 2px #111827}
 .range input[type=range]::-moz-range-thumb{width:18px;height:18px;border-radius:50%;background:#111827;border:2px solid #fff;box-shadow:0 0 0 2px #111827}
 .range-meta{display:flex;justify-content:space-between;font-size:12px;color:#6b7280}
+
+/* bar comparison */
+.creo-bar-chart{display:grid;gap:12px}
+.creo-bar-chart .bar-row{display:grid;grid-template-columns:auto 1fr auto;align-items:center;gap:12px;font-size:13px;color:#1f2937}
+.creo-bar-chart .bar-row .bar{background:#e5e7eb;border-radius:999px;height:8px;overflow:hidden}
+.creo-bar-chart .bar-row .bar span{display:block;height:100%;background:#0ea5e9;border-radius:999px}
+.creo-bar-chart .bar-row.highlight .bar span{background:#16a34a}
+.creo-bar-chart .bar-row strong{font-size:13px;color:#0f172a}
+.creo-bar-chart .bar-row span:first-child{font-weight:600}
+
+/* metric bullets */
+.creo-bullets{list-style:none;padding:0;margin:0;display:grid;gap:8px;font-size:13px;color:#475569}
+.creo-bullets li{background:#f8fafc;border:1px solid #e5e7eb;border-radius:10px;padding:10px 12px}
+.creo-bullets li strong{display:block;font-size:12px;text-transform:uppercase;letter-spacing:.02em;margin-bottom:4px;color:#0f172a}
 
 /* disclaimer */
 .creo-disclaimer{font-size:12px;color:#6b7280;margin:4px 0 12px}

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -86,6 +86,15 @@
         ['term','Loan Term','number',tab.data?.term ?? 30],
         ['monthly_rent','Monthly Rent','number',tab.data?.monthly_rent ?? 2000],
         ['rent_appreciation','Rent Appreciation %','number',tab.data?.rent_appreciation ?? 2],
+        ['tax_yearly','Property Taxes (Yearly)','number',tab.data?.tax_yearly ?? 6000],
+        ['ins_yearly','Home Insurance (Yearly)','number',tab.data?.ins_yearly ?? 1200],
+        ['hoa_month','HOA Fees (Monthly)','number',tab.data?.hoa_month ?? 0],
+        ['pmi_yearly','PMI (Yearly)','number',tab.data?.pmi_yearly ?? 0],
+        ['annual_costs','Annual Costs %','number',tab.data?.annual_costs ?? 1],
+        ['selling_costs','Selling Costs %','number',tab.data?.selling_costs ?? 6],
+        ['annual_app','Annual Appreciation %','number',tab.data?.annual_app ?? 3],
+        ['renters_ins_pct','Renters Insurance %','number',tab.data?.renters_ins_pct ?? 1.3],
+        ['marginal_tax','Marginal Tax Bracket %','number',tab.data?.marginal_tax ?? 25],
       ],
       va_purchase: [
         ['home_value','Home Value','number',tab.data?.home_value ?? 200000],
@@ -196,213 +205,428 @@
 
   // render UI
   function render(pane, type, d, form, id){
-    const donut = pane.querySelector('.creo-donut');
-    const legend = pane.querySelector('.creo-legend');
-    const kstack = pane.querySelector('.kpi-stack');
-    const monthly = pane.querySelector('[data-role="monthly"]');
-    const controls = pane.querySelector('[data-role="controls"]');
-    const summary = pane.querySelector('.creo-summary');
+    const copy = state.tabs[id]?.data || {};
+    const rows = {
+      r1: pane.querySelector('[data-role="row1"]'),
+      r2: pane.querySelector('[data-role="row2"]'),
+      r3: pane.querySelector('[data-role="row3"]'),
+      r4: pane.querySelector('[data-role="row4"]'),
+      r5: pane.querySelector('[data-role="row5"]'),
+      r6: pane.querySelector('[data-role="row6"]'),
+    };
+    const disclaimer = pane.querySelector('.creo-disclaimer');
 
-    donut.innerHTML = ''; legend.innerHTML = '';
-    kstack.innerHTML = ''; monthly.innerHTML = ''; controls.innerHTML = '';
-    if (summary) summary.textContent = '';
+    Object.values(rows).forEach(row => {
+      if (!row) return;
+      row.innerHTML = '';
+      row.classList.add('is-empty');
+    });
 
-    function fillKpis(list){
-      kstack.innerHTML = '';
-      list.forEach(k=>{
-        const el = document.createElement('div');
-        const cls = `kpi${k.neg?' neg':''}${k.dark?' dark':''}${k.cls?` ${k.cls}`:''}`;
-        el.className = cls.trim();
-        const val = k.raw ?? (typeof k.value==='number' ? money(k.value) : String(k.value||''));
-        el.innerHTML = `<div class="small">${k.label||''}</div><div class="big">${val}</div>`;
-        kstack.appendChild(el);
-      });
-    }
-    function pieBlock(src){
-      if (!src || !Array.isArray(src.monthly)) {
-        donut.innerHTML = '<div class="pie"><div class="center">$0.00<small>per month</small></div></div>';
+    function setRow(key, nodes){
+      const row = rows[key];
+      if (!row) return;
+      row.innerHTML = '';
+      if (!nodes || !nodes.length){
+        row.classList.add('is-empty');
         return;
       }
-      const cols = src.colors || ['#f59e0b','#34d399','#10b981','#2563eb','#8b5cf6'];
-      const slices = src.monthly.map((s,i)=>({v:Number(s.v)||0,c:cols[i%cols.length],label:s.label}));
-      window.CreoPie(donut, slices);
-      legend.innerHTML = slices.map(s=>`<div class="item"><span class="swatch" style="background:${s.c}"></span><span>${s.label} ${money(s.v)}</span></div>`).join('');
+      row.classList.remove('is-empty');
+      nodes.forEach(node => row.appendChild(node));
     }
-    function slab(el, rows){ el.innerHTML = (rows||[]).map(r=>`<div><strong>${r.label}</strong><span>${typeof r.v==='string'?r.v:money(r.v)}</span></div>`).join(''); }
+
+    function createCard(title, opts = {}){
+      const card = document.createElement('div');
+      card.className = `creo-card${opts.cls ? ' '+opts.cls : ''}`;
+      if (title || opts.actions){
+        const head = document.createElement('div');
+        head.className = 'creo-card-h';
+        if (title){
+          const h = document.createElement('h3');
+          h.textContent = title;
+          head.appendChild(h);
+        }
+        if (opts.actions) head.appendChild(opts.actions);
+        card.appendChild(head);
+      }
+      if (opts.info){
+        const p = document.createElement('p');
+        p.className = 'creo-card-copy';
+        p.textContent = opts.info;
+        card.appendChild(p);
+      }
+      if (opts.body){
+        if (typeof opts.body === 'string') card.insertAdjacentHTML('beforeend', opts.body);
+        else card.appendChild(opts.body);
+      }
+      return card;
+    }
+
+    function buildSlab(items){
+      const slab = document.createElement('div');
+      slab.className = 'creo-slab';
+      slab.innerHTML = (items || []).map(row => {
+        const val = row.raw ?? (typeof row.v === 'string' ? row.v : money(row.v));
+        return `<div><strong>${row.label}</strong><span>${val}</span></div>`;
+      }).join('');
+      return slab;
+    }
+
+    function buildKpiStack(list){
+      const stack = document.createElement('div');
+      stack.className = 'kpi-stack';
+      (list || []).forEach(k => {
+        const el = document.createElement('div');
+        const cls = ['kpi'];
+        if (k.neg) cls.push('neg');
+        if (k.dark) cls.push('dark');
+        if (k.cls) cls.push(k.cls);
+        el.className = cls.join(' ').trim();
+        const val = k.raw ?? (typeof k.value === 'number' ? money(k.value) : (k.value ?? ''));
+        el.innerHTML = `<div class="small">${k.label || ''}</div><div class="big">${val}</div>`;
+        stack.appendChild(el);
+      });
+      return stack;
+    }
+
+    function buildDonutCard(title, info, src){
+      const card = createCard(title, {info, cls:'chart-card'});
+      const donut = document.createElement('div');
+      donut.className = 'creo-donut';
+      const legend = document.createElement('div');
+      legend.className = 'creo-legend';
+      card.appendChild(donut);
+      card.appendChild(legend);
+      if (src && Array.isArray(src.monthly) && src.monthly.length){
+        const cols = src.colors || ['#f59e0b','#34d399','#10b981','#2563eb','#8b5cf6'];
+        const slices = src.monthly.map((s,i)=>({
+          v: Number(s.v)||0,
+          c: cols[i%cols.length],
+          label: s.label
+        }));
+        window.CreoPie(donut, slices);
+        legend.innerHTML = slices.map(s=>`<div class="item"><span class="swatch" style="background:${s.c}"></span><span>${s.label} ${money(s.v)}</span></div>`).join('');
+      } else {
+        donut.innerHTML = '<div class="pie"><div class="center">$0.00<small>per month</small></div></div>';
+        legend.innerHTML = '';
+      }
+      return card;
+    }
+
+    function buildListCard(title, items, info, cls){
+      return createCard(title, {info, body: buildSlab(items || []), cls});
+    }
+
+    function buildSummaryCard(text, title){
+      const body = document.createElement('div');
+      body.className = 'creo-summary';
+      body.innerHTML = text || 'Results received from this calculator are for comparison only. Accuracy is not guaranteed. Confirm numbers with your loan officer.';
+      return createCard(title || 'Summary', {body, cls:'summary-card'});
+    }
+
+    function buildRangeControls(homeVal, downVal, opts){
+      const card = createCard(opts?.title || 'Adjust Your Numbers', {cls:'controls-card'});
+      const priceTitle = document.createElement('div');
+      priceTitle.className = 'creo-card-h';
+      priceTitle.innerHTML = '<h3>Purchase Price</h3>';
+      const priceWrap = document.createElement('div');
+      priceWrap.className = 'range';
+      priceWrap.innerHTML = `<input type="range" min="50000" max="2000000" step="1000" name="_price" value="${homeVal}"><div class="range-meta"><span>${money(50000)}</span><span>${money(homeVal)}</span><span>${money(2000000)}</span></div>`;
+      const downTitle = document.createElement('div');
+      downTitle.className = 'creo-card-h';
+      downTitle.innerHTML = '<h3>Down Payment</h3>';
+      const downWrap = document.createElement('div');
+      downWrap.className = 'range';
+      const downMax = Math.max(0, Math.round((opts?.downMaxFactor ?? 0.5) * homeVal));
+      downWrap.innerHTML = `<input type="range" min="0" max="${downMax}" step="500" name="_down" value="${downVal}"><div class="range-meta"><span>${money(0)}</span><span>${money(downVal)}</span><span>${money(downMax)}</span></div>`;
+      card.appendChild(priceTitle);
+      card.appendChild(priceWrap);
+      card.appendChild(downTitle);
+      card.appendChild(downWrap);
+
+      const priceEl = card.querySelector('input[name="_price"]');
+      const downEl = card.querySelector('input[name="_down"]');
+
+      priceEl.oninput = debounce(e => {
+        const v = parseFloat(e.target.value||0);
+        if (opts?.homeField) form.querySelector(`[name="${opts.homeField}"]`).value = v;
+        if (opts?.baseField){
+          const currentDown = parseFloat(form.querySelector(`[name="${opts.downField}"]`)?.value || 0);
+          form.querySelector(`[name="${opts.baseField}"]`).value = Math.max(0, v - currentDown);
+        }
+        const max = Math.max(0, Math.round((opts?.downMaxFactor ?? 0.5) * v));
+        downEl.max = max;
+        const spans = downEl.nextElementSibling?.querySelectorAll('span');
+        if (spans && spans[2]) spans[2].textContent = money(max);
+        calculate(form, id);
+      }, 80);
+
+      downEl.oninput = debounce(e => {
+        const v = parseFloat(e.target.value||0);
+        if (opts?.downField) form.querySelector(`[name="${opts.downField}"]`).value = v;
+        if (opts?.baseField){
+          const homeValCurrent = parseFloat(form.querySelector(`[name="${opts.homeField}"]`)?.value || 0);
+          form.querySelector(`[name="${opts.baseField}"]`).value = Math.max(0, homeValCurrent - v);
+        }
+        const spans = downEl.nextElementSibling?.querySelectorAll('span');
+        if (spans && spans[1]) spans[1].textContent = money(v);
+        calculate(form, id);
+      }, 80);
+
+      return card;
+    }
+
+    function pctText(v){
+      return `${Number(v || 0).toFixed(2)}%`;
+    }
+
     const loanVal = byLabel(d?.monthlyBreak,'mortgage amount') ?? byLabel(d?.monthlyBreak,'loan amount');
 
+    if (copy.disclaimer && disclaimer){
+      disclaimer.textContent = copy.disclaimer;
+    }
+
     // ------- Types -------
-    if (type==='affordability'){
-      const totalM = sum(d?.donut?.monthly||[]);
-      fillKpis([
+    if (type === 'affordability'){
+      const totalM = sum(d?.donut?.monthly || []);
+      const homeVal = byLabel(d?.monthlyBreak, 'home value') ?? Number(form.querySelector('[name="home_price"]')?.value || 200000);
+      const downVal = Number(form.querySelector('[name="down_payment"]')?.value || 0);
+
+      const kpis = buildKpiStack([
         {label:'Monthly Mortgage Payment', value: totalM, cls:'kpi-lg kpi-navy'},
         {label:'Loan Amount', value: loanVal ?? 0, cls:'kpi-lg kpi-navy'},
         {label:'Your Debt to Income Ratio', raw: String(d?.afford?.dti_you || '0.00% / 0.00%')},
         {label:'Allowable Debt to Income Ratio', raw: String(d?.afford?.dti_allowed || '50% / 50%')}
       ]);
-      pieBlock(d?.donut);
-      slab(monthly, d?.monthlyBreak || []);
 
-      // sliders (Purchase Price & Down Payment)
-      const homeVal = byLabel(d?.monthlyBreak, 'home value') ?? Number(form.querySelector('[name="home_price"]')?.value || 200000);
-      const downVal = Number(form.querySelector('[name="down_payment"]')?.value || 0);
+      setRow('r1', [
+        buildDonutCard(copy.pay_title || 'Payment Breakdown', copy.pay_info || '', d?.donut),
+        kpis
+      ]);
 
-      controls.innerHTML = `
-        <div class="creo-card-h"><h3>Purchase Price</h3></div>
-        <div class="range">
-          <input type="range" min="50000" max="2000000" step="1000" name="_price" value="${homeVal}">
-          <div class="range-meta"><span>${money(50000)}</span><span>${money(homeVal)}</span><span>${money(2000000)}</span></div>
-        </div>
-        <div class="creo-card-h"><h3>Down Payment</h3></div>
-        <div class="range">
-          <input type="range" min="0" max="${Math.max(0, Math.round(homeVal*0.5))}" step="500" name="_down" value="${downVal}">
-          <div class="range-meta"><span>${money(0)}</span><span>${money(downVal)}</span><span>${money(Math.max(0, Math.round(homeVal*0.5)))}</span></div>
-        </div>
-      `;
+      setRow('r2', [
+        buildListCard('Loan Details', d?.monthlyBreak || []),
+        buildRangeControls(homeVal, downVal, {homeField:'home_price', downField:'down_payment'})
+      ]);
 
-      const priceEl = controls.querySelector('input[name="_price"]');
-      const downEl  = controls.querySelector('input[name="_down"]');
-      priceEl.oninput = debounce((e)=>{
-        const v = parseFloat(e.target.value||0);
-        form.querySelector('[name="home_price"]').value = v;
-        // adjust down slider ceiling when price moves
-        downEl.max = Math.max(0, Math.round(v*0.5));
-        calculate(form, id);
-      }, 80);
-      downEl.oninput = debounce((e)=>{
-        form.querySelector('[name="down_payment"]').value = parseFloat(e.target.value||0);
-        calculate(form, id);
-      }, 80);
+      const dpPct = homeVal > 0 ? (downVal/homeVal) * 100 : 0;
+      const summaryText =
+        `Based on what you input today your <strong>Total Payment</strong> would be <strong>${money(totalM)}</strong>`+
+        ` on a <strong>Conventional Loan</strong> with a <strong>${dpPct.toFixed(1)}% Down Payment</strong>. `+
+        `Your <strong>Debt-to-Income Ratio</strong> is <strong>${d?.afford?.dti_you || '--'}</strong> `+
+        `and the maximum allowable on this program type is <strong>${d?.afford?.dti_allowed || '50%/50%'}</strong>. `+
+        `Please confirm all numbers for accuracy with your loan officer.`;
 
-      if (summary) {
-        const dpPct = homeVal>0 ? (downVal/homeVal)*100 : 0;
-        summary.innerHTML =
-          `Based on what you input today your <strong>Total Payment</strong> would be <strong>${money(totalM)}</strong>` +
-          ` on a <strong>Conventional Loan</strong> with a <strong>${dpPct.toFixed(1)}% Down Payment</strong>. ` +
-          `Your <strong>Debt-to-Income Ratio</strong> is <strong>${d?.afford?.dti_you || '--'}</strong> ` +
-          `and the maximum allowable on this program type is <strong>${d?.afford?.dti_allowed || '50%/50%'}</strong>. ` +
-          `Please confirm all numbers for accuracy with your loan officer.`;
-      }
+      setRow('r3', [buildSummaryCard(summaryText)]);
       return;
     }
 
-    if (type==='purchase' || type==='va_purchase'){
-      fillKpis([
-        {label:'Monthly Mortgage Payment', value: sum(d?.donut?.monthly||[]), cls:'kpi-lg kpi-navy'},
-        {label:'Total Loan Amount', value: loanVal || 0, cls:'kpi-lg kpi-navy'},
-        {label:'Total Interest Paid', value: Number(d?.kpis?.[2]?.value || 0)},
-        {label:'', value: 0}
-      ]);
-      pieBlock(d?.donut);
-      slab(monthly, d?.monthlyBreak || []);
-
-      // sliders to mirror screenshot
+    if (type === 'purchase' || type === 'va_purchase'){
+      const totalMonthly = sum(d?.donut?.monthly || []);
       const homeVal = byLabel(d?.monthlyBreak, 'home value') ?? Number(form.querySelector('[name="home_value"]')?.value || 200000);
       const downVal = Number(form.querySelector('[name="down_payment"]')?.value || 0);
 
-      controls.innerHTML = `
-        <div class="creo-card-h"><h3>Purchase Price</h3></div>
-        <div class="range">
-          <input type="range" min="50000" max="2000000" step="1000" name="_price" value="${homeVal}">
-          <div class="range-meta"><span>${money(50000)}</span><span>${money(homeVal)}</span><span>${money(2000000)}</span></div>
-        </div>
-        <div class="creo-card-h"><h3>Down Payment</h3></div>
-        <div class="range">
-          <input type="range" min="0" max="${Math.max(0, Math.round(homeVal*0.5))}" step="500" name="_down" value="${downVal}">
-          <div class="range-meta"><span>${money(0)}</span><span>${money(downVal)}</span><span>${money(Math.max(0, Math.round(homeVal*0.5)))}</span></div>
-        </div>
-      `;
-      const priceEl = controls.querySelector('input[name="_price"]');
-      const downEl  = controls.querySelector('input[name="_down"]');
-      priceEl.oninput = debounce((e)=>{
-        const v = parseFloat(e.target.value||0);
-        form.querySelector('[name="home_value"]').value = v;
-        form.querySelector('[name="base_amount"]').value = Math.max(0, v - Number(form.querySelector('[name="down_payment"]').value||0));
-        downEl.max = Math.max(0, Math.round(v*0.5));
-        calculate(form, id);
-      }, 80);
-      downEl.oninput = debounce((e)=>{
-        const v = parseFloat(e.target.value||0);
-        form.querySelector('[name="down_payment"]').value = v;
-        const hv = Number(form.querySelector('[name="home_value"]').value||0);
-        form.querySelector('[name="base_amount"]').value = Math.max(0, hv - v);
-        calculate(form, id);
-      }, 80);
+      const kpis = buildKpiStack([
+        {label:'Monthly Mortgage Payment', value: totalMonthly, cls:'kpi-lg kpi-navy'},
+        {label:'Total Loan Amount', value: loanVal || d?.kpis?.[1]?.value || 0, cls:'kpi-lg kpi-navy'},
+        {label:'Total Interest Paid', value: d?.kpis?.[2]?.value || 0},
+        {label:'Down Payment', value: downVal}
+      ]);
+
+      const donutCard = buildDonutCard(copy.pay_title || 'Payment Breakdown', copy.pay_info || '', d?.donut);
+      setRow('r1', [donutCard, kpis]);
+
+      setRow('r2', [
+        buildListCard('Loan Details', d?.monthlyBreak || []),
+        buildRangeControls(homeVal, downVal, {homeField:'home_value', downField:'down_payment', baseField:'base_amount'})
+      ]);
+
+      const infoCards = [];
+      if (copy.early_title || copy.early_info){
+        infoCards.push(createCard(copy.early_title || 'Early Payoff Strategy', {info: copy.early_info || '', cls:'info-card'}));
+      }
+      if (copy.lump_title || copy.lump_info){
+        infoCards.push(createCard(copy.lump_title || 'Lump Sum Payment', {info: copy.lump_info || '', cls:'info-card'}));
+      }
+      if (type === 'va_purchase' && d?.fee){
+        infoCards.push(buildListCard('Funding Fee', [
+          {label:'Funding Fee Percentage', raw: pctText((d.fee.pct || 0) * 100)},
+          {label:'Financed Amount', v: d.fee.amount || 0},
+          {label:'First Use', raw: d.fee.first ? 'Yes' : 'No'},
+        ]));
+      }
+      if (infoCards.length) setRow('r3', infoCards);
+
+      const dpPct = homeVal > 0 ? (downVal/homeVal) * 100 : 0;
+      const summaryText = `Your estimated total monthly payment is <strong>${money(totalMonthly)}</strong> with a loan amount of <strong>${money(loanVal || 0)}</strong> and a down payment of <strong>${money(downVal)} (${dpPct.toFixed(1)}%)</strong>. Review property taxes, insurance and HOA dues for accuracy with your loan officer.`;
+      setRow('r4', [buildSummaryCard(summaryText)]);
       return;
     }
 
-    if (type==='refinance' || type==='va_refinance'){
-      const c = d?.compare || {};
-      const diff = Number(c?.diff || 0);
-      fillKpis([
+    if (type === 'refinance' || type === 'va_refinance'){
+      const compare = d?.compare || {};
+      const diff = Number(compare.diff || 0);
+      const kpis = buildKpiStack([
         {label: diff>0 ? 'Monthly Payment Increase' : 'Monthly Payment Decrease', value: Math.abs(diff), neg: diff>0, cls:'kpi-lg kpi-navy'},
-        {label:'Total Interest Difference', value: Math.abs(Number(c?.interest?.diff||0)), neg: Number(c?.interest?.diff||0)>0, cls:'kpi-lg kpi-navy'},
+        {label:'Total Interest Difference', value: Math.abs(Number(compare.interest?.diff || 0)), neg: Number(compare.interest?.diff || 0) > 0, cls:'kpi-lg kpi-navy'},
         {label:'Refinance Costs', value: Number(d?.costs || 0)},
-        {label:'Time to Recoup Fees', raw: String(d?.recoup_time || '--')}
+        {label:'Time to Recoup Fees', raw: d?.recoup_time ? `${d.recoup_time} months` : '--'}
       ]);
-      donut.innerHTML = `
-        <div class="creo-slab" style="width:100%">
-          <div><strong>Current Loan</strong><span>${money(c?.current||0)}</span></div>
-          <div><strong>New Loan</strong><span>${money(c?.new||0)}</span></div>
-          <div><strong>Monthly Payment Difference</strong><span>${money(diff)}</span></div>
-          <div><strong>Current Remaining Interest</strong><span>${money(c?.interest?.current||0)}</span></div>
-          <div><strong>New Loan Interest</strong><span>${money(c?.interest?.new||0)}</span></div>
-          <div><strong>Total Interest Difference</strong><span>${money(c?.interest?.diff||0)}</span></div>
-        </div>`;
-      legend.innerHTML = '';
-      slab(monthly, d?.monthlyBreak || []);
-      controls.innerHTML = `
-        <div class="creo-card-h"><h3>Refinance Options</h3></div>
-        <div class="creo-slab">
-          <div><strong>New Rate</strong><span>${pct(d?.rate || 0)}</span></div>
-          <div><strong>New Term</strong><span>${Number(d?.term || 0)} years</span></div>
-        </div>`;
+
+      const compTitle = type === 'va_refinance' ? (copy.monthly_comp_title || 'Monthly Payment Comparison') : 'Monthly Payment Comparison';
+      const compInfo = type === 'va_refinance' ? (copy.monthly_comp_info || '') : '';
+      const compCard = createCard(compTitle, {info: compInfo, cls:'comparison-card', body: buildSlab([
+        {label:'Current Monthly Payment', v: compare.current || 0},
+        {label:'New Monthly Payment', v: compare.new || 0},
+        {label:'Monthly Payment Difference', v: diff},
+      ])});
+
+      setRow('r1', [compCard, kpis]);
+
+      const interestTitle = type === 'va_refinance' ? (copy.interest_comp_title || 'Total Interest Comparison') : 'Total Interest Comparison';
+      const interestInfo = type === 'va_refinance' ? (copy.interest_comp_info || '') : '';
+      const interestCard = createCard(interestTitle, {info: interestInfo, body: buildSlab([
+        {label:'Current Remaining Interest', v: compare.interest?.current || 0},
+        {label:'New Loan Interest', v: compare.interest?.new || 0},
+        {label:'Total Interest Difference', v: compare.interest?.diff || 0},
+      ])});
+
+      const optionsCard = createCard('Refinance Options', {body: buildSlab([
+        {label:'New Rate', raw: pctText(d?.rate || 0)},
+        {label:'New Term', raw: `${Number(d?.term || 0)} years`},
+        ...(d?.cash_out ? [{label:'Cash Out Amount', v: d.cash_out}] : [])
+      ])});
+
+      setRow('r2', [interestCard, optionsCard]);
+      setRow('r3', [buildListCard('Loan Details', d?.monthlyBreak || [])]);
+
+      const summaryText = diff < 0
+        ? `Refinancing lowers your payment by <strong>${money(Math.abs(diff))}</strong> each month. You will recover your upfront costs in approximately <strong>${d?.recoup_time || 0} months</strong>.`
+        : `Refinancing increases your payment by <strong>${money(Math.abs(diff))}</strong> each month. Evaluate whether saving <strong>${money(Math.abs(Number(compare.interest?.diff || 0)))}</strong> in interest makes sense for your goals.`;
+      setRow('r4', [buildSummaryCard(summaryText)]);
       return;
     }
 
-    if (type==='dscr'){
-      fillKpis([
-        {label:'Cash Flow', value:Number(d?.returns?.cash_flow||0), neg:Number(d?.returns?.cash_flow||0)<0, cls:'kpi-lg kpi-navy'},
-        {label:'Cap Rate', raw:pct(d?.returns?.cap_rate||0), cls:'kpi-lg kpi-navy'},
-        {label:'Cash on Cash Return', raw:pct(d?.returns?.coc||0)},
-        {label:'DSCR', raw:String(Number(d?.returns?.dscr||0).toFixed(2))}
-      ]);
-      pieBlock(d?.donut);
-      slab(monthly, d?.monthlyBreak || []);
-      controls.innerHTML = `
-        <div class="creo-card-h"><h3>Deal Metrics</h3></div>
-        <div class="creo-slab">
-          <div><strong>Cash Needed to Close</strong><span>${money(d?.metrics?.cash_needed||0)}</span></div>
-          <div><strong>Operating Expenses</strong><span>${money(d?.metrics?.operating||0)}</span></div>
-        </div>`;
+    if (type === 'rentbuy'){
+      const kpis = buildKpiStack((d?.kpis || []).map((item, idx) => {
+        if (idx === 0) return {label:item.label, raw:String(item.value)};
+        return {label:item.label, value:item.value, cls: idx === 3 ? 'kpi-lg kpi-navy' : ''};
+      }));
+      const donutCard = buildDonutCard('Monthly Ownership Breakdown', '', d?.donut);
+      setRow('r1', [donutCard, kpis]);
+
+      const comparison = d?.comparison || {};
+      const rentTotal = Number(comparison.rent_total || 0);
+      const buyTotal = Number(comparison.buy_total || 0);
+      const netAdv = Number(comparison.net_advantage || 0);
+      const maxVal = Math.max(rentTotal, buyTotal, Math.abs(netAdv), 1);
+      const barCard = createCard('Rent vs Buy Comparison', {cls:'bars-card', body: (() => {
+        const wrap = document.createElement('div');
+        wrap.className = 'creo-bar-chart';
+        wrap.innerHTML = `
+          <div class="bar-row"><span>Renting Cost</span><div class="bar"><span style="width:${(rentTotal/maxVal)*100}%"></span></div><strong>${money(rentTotal)}</strong></div>
+          <div class="bar-row"><span>Buying Cost</span><div class="bar"><span style="width:${(buyTotal/maxVal)*100}%"></span></div><strong>${money(buyTotal)}</strong></div>
+          <div class="bar-row highlight"><span>Net Worth Difference</span><div class="bar"><span style="width:${(Math.abs(netAdv)/maxVal)*100}%"></span></div><strong>${money(netAdv)}</strong></div>`;
+        return wrap;
+      })()});
+
+      setRow('r2', [barCard, buildListCard('Loan Details', d?.monthlyBreak || [])]);
+
+      const years = Number(d?.kpis?.[0]?.value || 0);
+      const summaryText = `After ${years} years, owning could build <strong>${money(comparison.net_home || 0)}</strong> in equity compared to renting. The projected net advantage of buying is <strong>${money(netAdv)}</strong>.`;
+      setRow('r3', [buildSummaryCard(summaryText)]);
       return;
     }
 
-    if (type==='fixflip'){
-      fillKpis([
-        {label:'Borrower Equity Needed', value:Number(d?.metrics?.borrower_equity||0), cls:'kpi-lg kpi-navy'},
-        {label:'Net Profit', value:Number(d?.metrics?.net_profit||0), cls:'kpi-lg kpi-navy'},
-        {label:'Return on Investment', raw:pct(d?.metrics?.roi||0)},
-        {label:'Loan to After Repaired Value', raw:pct(d?.metrics?.ltv_to_arv||0)}
+    if (type === 'dscr'){
+      const returns = d?.returns || {};
+      const metrics = d?.metrics || {};
+      const deal = d?.dealBreak || [];
+
+      const returnCard = createCard(copy.return_title || 'Return Metrics', {
+        info: copy.return_info || '',
+        body: buildSlab([
+          {label:'Cash Flow', v: returns.cash_flow || 0},
+          {label:'Cap Rate', raw: pctText(returns.cap_rate || 0)},
+          {label:'Cash on Cash Return', raw: pctText(returns.coc || 0)},
+          {label:'DSCR', raw: Number(returns.dscr || 0).toFixed(2)},
+        ])
+      });
+
+      setRow('r1', [
+        buildListCard(copy.deal_title || 'Deal Breakdown', deal, copy.deal_info || ''),
+        returnCard
       ]);
-      pieBlock(d?.donut);
-      slab(monthly, d?.dealBreak || d?.monthlyBreak || []);
-      controls.innerHTML = `
-        <div class="creo-card-h"><h3>Deal Breakdown</h3></div>
-        <div class="creo-slab">
-          <div><strong>Closing Costs</strong><span>${money(d?.metrics?.closing_costs||0)}</span></div>
-          <div><strong>Carrying Costs</strong><span>${money(d?.metrics?.carrying_costs||0)}</span></div>
-        </div>`;
+
+      const metricsCard = createCard(copy.metrics_title || 'Deal Metrics', {
+        info: copy.metrics_info || '',
+        body: buildSlab([
+          {label:'Cash Needed to Close', v: metrics.cash_needed || 0},
+          {label:'Operating Expenses', v: metrics.operating || 0},
+          {label:'Loan to Value', raw: pctText(metrics.ltv || 0)},
+          {label:'Origination Fee', v: metrics.origination || 0},
+        ])
+      });
+
+      setRow('r2', [buildDonutCard('Income vs Expenses', '', d?.donut), metricsCard]);
+
+      const bullets = [];
+      if (copy.cash_flow_info) bullets.push(`<li><strong>Cash Flow</strong> ${copy.cash_flow_info}</li>`);
+      if (copy.cap_rate_info) bullets.push(`<li><strong>Cap Rate</strong> ${copy.cap_rate_info}</li>`);
+      if (copy.coc_info) bullets.push(`<li><strong>Cash on Cash</strong> ${copy.coc_info}</li>`);
+      if (copy.dscr_info) bullets.push(`<li><strong>DSCR</strong> ${copy.dscr_info}</li>`);
+      if (bullets.length){
+        const list = document.createElement('ul');
+        list.className = 'creo-bullets';
+        list.innerHTML = bullets.join('');
+        setRow('r3', [createCard('Understanding Your Metrics', {body: list, cls:'info-card'})]);
+      }
+
+      return;
+    }
+
+    if (type === 'fixflip'){
+      const returns = d?.returns || {};
+      const metrics = d?.metrics || {};
+      const deal = d?.dealBreak || [];
+
+      const returnsCard = createCard(copy.return_title || 'Return Metrics', {
+        info: copy.return_info || '',
+        body: buildSlab([
+          {label:'Borrower Equity Needed', v: returns.borrower_equity || 0},
+          {label:'Net Profit', v: returns.net_profit || 0},
+          {label:'Return on Investment', raw: pctText(returns.roi || 0)},
+          {label:'Loan to After Repaired Value', raw: pctText(returns.ltv_to_arv || 0)},
+        ])
+      });
+
+      setRow('r1', [buildDonutCard('Project Cost Allocation', '', d?.donut), returnsCard]);
+
+      const metricsCard = createCard(copy.metrics_title || 'Deal Metrics', {
+        info: copy.metrics_info || '',
+        body: buildSlab([
+          {label:'Closing Costs', v: metrics.closing_costs || 0},
+          {label:'Carrying Costs', v: metrics.carrying_costs || 0},
+          {label:'Total Cash In Deal', v: metrics.total_cash_in_deal || returns.borrower_equity || 0},
+          {label:'Selling Costs', v: metrics.selling_costs || 0},
+        ])
+      });
+
+      setRow('r2', [buildListCard(copy.deal_title || 'Deal Breakdown', deal, copy.deal_info || ''), metricsCard]);
+
+      const summaryText = `Based on your assumptions, this project requires <strong>${money(returns.borrower_equity || 0)}</strong> in cash and produces an estimated profit of <strong>${money(returns.net_profit || 0)}</strong>. That equals a <strong>${pctText(returns.roi || 0)}</strong> return with an LTV to ARV of <strong>${pctText(returns.ltv_to_arv || 0)}</strong>.`;
+      const summaryCard = buildSummaryCard(summaryText);
+      const extras = [summaryCard];
+      if (copy.analysis_title || copy.analysis_info){
+        extras.unshift(createCard(copy.analysis_title || 'Analysis Report', {info: copy.analysis_info || '', cls:'info-card'}));
+      }
+      setRow('r3', extras);
       return;
     }
 
     // fallback
-    fillKpis(Array.isArray(d?.kpis)?d.kpis.map(x=>({label:x.label, value:Number(x.value||0)})) : []);
-    pieBlock(d?.donut);
-    slab(monthly, d?.monthlyBreak || []);
-    controls.innerHTML = '';
+    setRow('r1', [buildDonutCard('Payment Breakdown', '', d?.donut), buildKpiStack((d?.kpis || []).map(item => ({label:item.label, value:item.value}))) ]);
+    setRow('r2', [buildListCard('Details', d?.monthlyBreak || [])]);
   }
-
   // pie via conic gradient
   window.CreoPie = function(container, slices){
     const total = slices.reduce((a,s)=>a + Math.max(0, Number(s.v)||0), 0);

--- a/includes/calculators/dscr.php
+++ b/includes/calculators/dscr.php
@@ -12,13 +12,17 @@ function creo_calc_dscr($d){
   $rep   = floatval($d['repairs'] ?? 500);
   $utils = floatval($d['utils'] ?? 3000);
   $hoa   = floatval($d['hoa'] ?? 0);
+  $closing = floatval($d['closing'] ?? 6500);
+  $origPct = floatval($d['orig_fee'] ?? 2)/100;
 
-  $opExp = $tax + $ins + $rep + $utils + ($hoa*12) + ($gross*$vac);
+  $vacancyLoss = $gross * $vac;
+  $opExp = $tax + $ins + $rep + $utils + ($hoa*12) + $vacancyLoss;
   $noi   = $gross - $opExp;
 
   $value = floatval($d['prop_value'] ?? 500000);
   $ltv   = floatval($d['ltv'] ?? 80)/100;
   $loan  = $value*$ltv;
+  $down  = max(0, $value - $loan);
 
   $rate  = floatval($d['rate'] ?? 10);
   $years = 30;
@@ -27,23 +31,52 @@ function creo_calc_dscr($d){
 
   $dscr  = $piY>0 ? $noi/$piY : 0;
 
-  // cash flow, cap rate, cash on cash return
   $cashFlow = $noi - $piY;
   $capRate = $value>0 ? ($noi/$value) : 0;
-  $coc     = ($loan>0) ? ($cashFlow/($value - $loan)) : 0;
+  $origination = $loan * $origPct;
+  $cashNeeded = $down + $closing + $origination;
+  $coc     = $cashNeeded>0 ? ($cashFlow/$cashNeeded) : 0;
 
   return [
-    'kpis'=>[
-      ['label'=>'Cash Flow','value'=>$cashFlow],
-      ['label'=>'Cap Rate','value'=>$capRate],
-      ['label'=>'Cash on Cash Return','value'=>$coc],
-      ['label'=>'DSCR','value'=>$dscr],
+    'returns'=>[
+      'cash_flow'=>$cashFlow,
+      'cap_rate'=>$capRate*100,
+      'coc'=>$coc*100,
+      'dscr'=>$dscr,
     ],
-    'breakdown'=>[
-      'loan_amount'=>$loan,
-      'down_payment'=>$value-$loan,
-      'mortgage'=>$piY,
-      'origination'=>$loan*(floatval($d['orig_fee']??2)/100),
-    ]
+    'donut'=>[
+      'monthly'=>[
+        ['label'=>'Net Operating Income','v'=>round($noi/12,2)],
+        ['label'=>'Debt Service','v'=>round($piY/12,2)],
+        ['label'=>'Vacancy Loss','v'=>round($vacancyLoss/12,2)],
+        ['label'=>'Operating Expenses','v'=>round(($opExp-$vacancyLoss)/12,2)],
+      ],
+      'colors'=>['#16a34a','#0ea5e9','#f97316','#fbbf24'],
+    ],
+    'monthlyBreak'=>[
+      ['label'=>'Gross Scheduled Rent','v'=>$gross/12],
+      ['label'=>'Vacancy Allowance','v'=>$vacancyLoss/12],
+      ['label'=>'Net Operating Income','v'=>$noi/12],
+      ['label'=>'Debt Service','v'=>$piY/12],
+      ['label'=>'Monthly Cash Flow','v'=>$cashFlow/12],
+      ['label'=>'Taxes (Monthly)','v'=>$tax/12],
+      ['label'=>'Insurance (Monthly)','v'=>$ins/12],
+      ['label'=>'HOA Fees','v'=>$hoa],
+      ['label'=>'Repairs & Maintenance (Monthly)','v'=>$rep/12],
+      ['label'=>'Utilities (Monthly)','v'=>$utils/12],
+    ],
+    'dealBreak'=>[
+      ['label'=>'Property Value','v'=>$value],
+      ['label'=>'Loan Amount','v'=>$loan],
+      ['label'=>'Down Payment','v'=>$down],
+      ['label'=>'Origination Fee','v'=>$origination],
+      ['label'=>'Closing Costs','v'=>$closing],
+    ],
+    'metrics'=>[
+      'cash_needed'=>$cashNeeded,
+      'operating'=>$opExp,
+      'ltv'=>$ltv*100,
+      'origination'=>$origination,
+    ],
   ];
 }

--- a/includes/calculators/fixflip.php
+++ b/includes/calculators/fixflip.php
@@ -9,45 +9,56 @@ function creo_calc_fixflip($d){
   $insY     = floatval($d['ins'] ?? 3000);
   $ltv      = floatval($d['ltv'] ?? 80)/100;
   $rate     = floatval($d['rate'] ?? 10);
-  $otherC   = floatval($d['closing'] ?? 15000);
+  $closingIn= floatval($d['other_closing'] ?? ($d['closing'] ?? 15000));
   $sellPct  = floatval($d['cost_to_sell'] ?? 8)/100;
+  $origPct  = floatval($d['orig_fee'] ?? 2)/100;
 
   $loanAmt = $purchase*$ltv;
   $down    = $purchase - $loanAmt;
 
-  // hold six months interest approximation
   $piM = creo_amort_payment($loanAmt,$rate,30);
   $carrying = $piM*6 + ($taxY/2) + ($insY/2);
 
   $sellCost = $arv*$sellPct;
-  $closing  = $otherC;
-  $equityNeeded = $down + $reno + $carrying + $closing;
-  $netProfit = $arv - ($purchase + $reno + $carrying + $closing + $sellCost);
+  $origination = $loanAmt * $origPct;
+  $cashNeeded = $down + $reno + $carrying + $closingIn + $origination;
+  $netProfit = $arv - ($purchase + $reno + $carrying + $closingIn + $sellCost + $origination);
 
-  $roi = $equityNeeded>0 ? $netProfit/$equityNeeded : 0;
+  $roi = $cashNeeded>0 ? ($netProfit/$cashNeeded) : 0;
   $ltvFinal = $arv>0 ? ($loanAmt/$arv) : 0;
 
   return [
-    'kpis'=>[
-      ['label'=>'Borrower Equity Needed','value'=>$equityNeeded],
-      ['label'=>'Net Profit','value'=>$netProfit],
-      ['label'=>'Return on Investment','value'=>$roi],
-      ['label'=>'Loan to After Repaired Value','value'=>$ltvFinal],
+    'returns'=>[
+      'borrower_equity'=>$cashNeeded,
+      'net_profit'=>$netProfit,
+      'roi'=>$roi*100,
+      'ltv_to_arv'=>$ltvFinal*100,
     ],
-    'deal'=>[
-      'loan_amount'=>$loanAmt,
-      'down_payment'=>$down,
-      'monthly_interest'=>$piM,
-      'interest_over_term'=>$piM*6,
-      'origination'=>$loanAmt*(floatval($d['orig_fee']??2)/100),
-      'other_closing'=>$otherC,
-      'cost_to_sell'=>$sellCost
+    'donut'=>[
+      'monthly'=>[
+        ['label'=>'Purchase Price','v'=>round($purchase,2)],
+        ['label'=>'Renovation Cost','v'=>round($reno,2)],
+        ['label'=>'Carrying Costs','v'=>round($carrying,2)],
+        ['label'=>'Closing & Fees','v'=>round($closingIn + $origination,2)],
+      ],
+      'colors'=>['#0ea5e9','#f97316','#facc15','#22c55e'],
+    ],
+    'dealBreak'=>[
+      ['label'=>'Purchase Price','v'=>$purchase],
+      ['label'=>'Renovation Cost','v'=>$reno],
+      ['label'=>'Loan Amount','v'=>$loanAmt],
+      ['label'=>'Down Payment','v'=>$down],
+      ['label'=>'Origination Fee','v'=>$origination],
+      ['label'=>'Carrying Costs','v'=>$carrying],
+      ['label'=>'Closing Costs','v'=>$closingIn],
+      ['label'=>'Cost to Sell','v'=>$sellCost],
     ],
     'metrics'=>[
-      'closing_costs'=>$closing,
+      'closing_costs'=>$closingIn,
       'carrying_costs'=>$carrying,
-      'borrower_equity'=>$equityNeeded,
-      'total_cash_in_deal'=>$equityNeeded,
-    ]
+      'borrower_equity'=>$cashNeeded,
+      'total_cash_in_deal'=>$cashNeeded,
+      'selling_costs'=>$sellCost,
+    ],
   ];
 }

--- a/includes/calculators/rentbuy.php
+++ b/includes/calculators/rentbuy.php
@@ -2,45 +2,92 @@
 if ( ! defined( 'ABSPATH' ) ) exit;
 
 function creo_calc_rentbuy($d){
-  $years = intval($d['years'] ?? 8);
+  $years = max(1, intval($d['years'] ?? 8));
   $home  = floatval($d['home_price'] ?? 500000);
   $down  = floatval($d['down'] ?? 50000);
-  $loan  = $home - $down;
+  $loan  = max(0.01, $home - $down);
   $rate  = floatval($d['rate'] ?? 7);
   $term  = intval($d['term'] ?? 30);
-  $start = $d['start'] ?? 'March 2020';
 
-  $rent0 = floatval($d['monthly_rent'] ?? 2000);
-  $rentApp = floatval($d['rent_appreciation'] ?? 2)/100.0;
+  $taxY  = floatval($d['tax_yearly'] ?? 6000);
+  $insY  = floatval($d['ins_yearly'] ?? 1200);
+  $hoaM  = floatval($d['hoa_month'] ?? 0);
+  $pmiY  = floatval($d['pmi_yearly'] ?? 0);
+  $maintPct = floatval($d['annual_costs'] ?? 1) / 100.0;
+  $sellPct  = floatval($d['selling_costs'] ?? 6) / 100.0;
+  $appPct   = floatval($d['annual_app'] ?? 3) / 100.0;
+  $rent0    = floatval($d['monthly_rent'] ?? 2000);
+  $rentApp  = floatval($d['rent_appreciation'] ?? 2) / 100.0;
+  $rentInsPct = floatval($d['renters_ins_pct'] ?? 1.3) / 100.0;
 
-  $piM = creo_amort_payment($loan,$rate,$term);
-  $buyTotal = 0; $rentTotal = 0; $equity = 0; $bal = $loan;
+  $piM   = creo_amort_payment($loan,$rate,$term);
+  $taxM  = $taxY / 12.0;
+  $insM  = $insY / 12.0;
+  $pmiM  = $pmiY / 12.0;
+  $maintM= ($home * $maintPct) / 12.0;
+  $ownMonthly = $piM + $taxM + $insM + $hoaM + $pmiM + $maintM;
 
+  $buyTotal = 0; $rentTotal = 0; $rentInsTotal = 0; $bal = $loan;
   $i = ($rate/100)/12;
 
   for ($m=1; $m<=($years*12); $m++){
-    // buy
-    $interest = $bal*$i;
+    $interest  = $bal*$i;
     $principal = $piM - $interest;
     $bal = max(0, $bal - $principal);
-    $equity += $principal;
-    $buyTotal += $piM;
+    $buyTotal += $piM + $taxM + $insM + $hoaM + $pmiM + $maintM;
 
-    // rent with yearly appreciation monthly rate
     $rentM = $rent0*pow(1+$rentApp, ($m-1)/12.0);
     $rentTotal += $rentM;
+    $rentInsTotal += $rentM * $rentInsPct;
   }
 
-  $gain = $equity - max(0,$rentTotal - $buyTotal);
+  $homeFuture = $home * pow(1+$appPct, $years);
+  $equity     = max(0, $homeFuture - $bal);
+  $sellingCosts = $homeFuture * $sellPct;
+  $netHome    = $equity - $sellingCosts;
+
+  $rentCost = $rentTotal + $rentInsTotal;
+  $netAdvantage = $netHome - max(0, $buyTotal - $rentCost);
 
   return [
     'kpis'=>[
-      ['label'=>'Year','value'=>$years],
-      ['label'=>'Buy Gain','value'=>$gain],
+      ['label'=>'Years Analyzed','value'=>$years],
+      ['label'=>'Total Cost of Renting','value'=>$rentCost],
+      ['label'=>'Total Cost of Buying','value'=>$buyTotal],
+      ['label'=>'Net Worth Difference','value'=>$netAdvantage],
     ],
-    'bars'=>[
-      'buy'=>$buyTotal,
-      'rent'=>$rentTotal,
-    ]
+    'donut'=>[
+      'monthly'=>[
+        ['label'=>'Principal & interest','v'=>round($piM,2)],
+        ['label'=>'Taxes','v'=>round($taxM,2)],
+        ['label'=>'Insurance','v'=>round($insM,2)],
+        ['label'=>'HOA Dues','v'=>round($hoaM,2)],
+        ['label'=>'PMI','v'=>round($pmiM,2)],
+        ['label'=>'Maintenance','v'=>round($maintM,2)],
+      ],
+      'colors'=>['#f59e0b','#22c55e','#fbbf24','#60a5fa','#a78bfa','#fb7185'],
+    ],
+    'monthlyBreak'=>[
+      ['label'=>'Home Value','v'=>$home],
+      ['label'=>'Down Payment','v'=>$down],
+      ['label'=>'Loan Amount','v'=>$loan],
+      ['label'=>'Monthly Principal & interest','v'=>$piM],
+      ['label'=>'Monthly Property Tax','v'=>$taxM],
+      ['label'=>'Monthly Home Insurance','v'=>$insM],
+      ['label'=>'Monthly HOA Fee','v'=>$hoaM],
+      ['label'=>'Monthly PMI','v'=>$pmiM],
+      ['label'=>'Monthly Maintenance','v'=>$maintM],
+    ],
+    'comparison'=>[
+      'rent_total'=>$rentCost,
+      'buy_total'=>$buyTotal,
+      'equity'=>$equity,
+      'net_home'=>$netHome,
+      'net_advantage'=>$netAdvantage,
+      'remaining_balance'=>$bal,
+      'future_value'=>$homeFuture,
+      'selling_costs'=>$sellingCosts,
+      'down_payment'=>$down,
+    ],
   ];
 }

--- a/includes/calculators/va-refinance.php
+++ b/includes/calculators/va-refinance.php
@@ -84,10 +84,22 @@ function creo_calc_va_refinance( $d ) {
         'diff'    => $interestNew - $interestCurrent,
       ],
     ],
+    'monthlyBreak' => [
+      [ 'label' => 'Current Monthly Payment', 'v' => $piCurrent ],
+      [ 'label' => 'New Monthly Payment',     'v' => $piNew ],
+      [ 'label' => 'Monthly Payment Difference', 'v' => $diffM ],
+      [ 'label' => 'Cash Out Amount',         'v' => $cashOut ],
+      [ 'label' => 'Refinance Costs',         'v' => $costs ],
+    ],
     'fee' => [
       'pct'    => $feePct,
       'amount' => $feeAmt,
       'irrrl'  => $isIRRRL ? 1 : 0,
     ],
+    'costs'      => $costs,
+    'rate'       => $newRate,
+    'term'       => $newTerm,
+    'cash_out'   => $cashOut,
+    'recoup_time'=> $recoupMonths,
   ];
 }

--- a/templates/frontend.php
+++ b/templates/frontend.php
@@ -20,7 +20,7 @@ foreach ($tabs as $id => $t) {
   </div>
 
   <?php $first = true; foreach ($enabled as $id => $tab): ?>
-    <section class="creo-calc"<?php echo $first ? '' : ' hidden'; ?> data-pane="<?php echo esc_attr($id); ?>">
+    <section class="creo-calc creo-type-<?php echo esc_attr($tab['type']); ?>"<?php echo $first ? '' : ' hidden'; ?> data-pane="<?php echo esc_attr($id); ?>">
       <div class="creo-grid">
         <!-- LEFT: dark form panel with two column inputs -->
         <aside class="creo-left">
@@ -38,33 +38,15 @@ foreach ($tabs as $id => $t) {
         </aside>
 
         <!-- RIGHT: fixed two row results layout -->
-        <section class="creo-right">
-          <!-- Row 1 -->
-          <div class="creo-row row-one">
-            <div class="creo-card chart-card">
-              <div class="creo-card-h"><h3>Payment Breakdown</h3></div>
-              <div class="creo-donut"></div>
-              <div class="creo-legend"></div>
-            </div>
-            <div class="kpi-stack" aria-label="Key metrics"><!-- JS --></div>
-          </div>
-
-          <!-- Row 2 -->
-          <div class="creo-row row-two">
-            <div class="creo-card details-card">
-              <div class="creo-card-h"><h3>Loan Details</h3></div>
-              <div class="creo-slab" data-role="monthly"><!-- JS --></div>
-            </div>
-
-            <div class="rightcol">
-              <div class="creo-card controls-card" data-role="controls"><!-- JS --></div>
-              <div class="creo-card summary-card">
-                <div class="creo-card-h"><h3>Summary</h3></div>
-                <div class="creo-summary">
-                  Results received from this calculator are for comparison only. Accuracy is not guaranteed. Confirm numbers with your loan officer.
-                </div>
-              </div>
-            </div>
+        <section class="creo-right" data-type="<?php echo esc_attr($tab['type']); ?>">
+          <div class="creo-row row-one" data-role="row1"></div>
+          <div class="creo-row row-two" data-role="row2"></div>
+          <div class="creo-row row-three" data-role="row3"></div>
+          <div class="creo-row row-four" data-role="row4"></div>
+          <div class="creo-row row-five" data-role="row5"></div>
+          <div class="creo-row row-six" data-role="row6"></div>
+          <div class="creo-disclaimer">
+            Results received from this calculator are for comparison only. Accuracy is not guaranteed. Confirm numbers with your loan officer.
           </div>
         </section>
       </div>


### PR DESCRIPTION
## Summary
- restructure the frontend template to expose tab-specific result rows for custom layouts and disclaimers
- overhaul the frontend renderer to build card-based sections per calculator type, expanded rent vs buy inputs, and slider controls
- expand PHP calculators to return detailed breakdown data for VA purchase/refinance, rent vs buy, DSCR, and fix & flip while refreshing styles for new components

## Testing
- php -l includes/calculators/refinance.php
- php -l includes/calculators/va-purchase.php
- php -l includes/calculators/va-refinance.php
- php -l includes/calculators/rentbuy.php
- php -l includes/calculators/dscr.php
- php -l includes/calculators/fixflip.php


------
https://chatgpt.com/codex/tasks/task_e_68c8683a4088832ebffc35c686de7cba