### PR TITLE
Remove field stepper UI from calculators

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -58,9 +58,6 @@
 .creo-left .creo-inputs.afford-mode .field-label{display:flex;justify-content:space-between;font-size:11px;text-transform:uppercase;letter-spacing:.05em;color:#9ca3af;font-weight:600}
 .creo-left .creo-inputs.afford-mode .field-label span:first-child{color:#e2e8f0}
 .creo-left .creo-inputs.afford-mode .field-control{display:flex;align-items:center;gap:8px}
-.creo-left .creo-inputs.afford-mode .field-btn{width:38px;height:38px;border-radius:12px;border:1px solid #2a2f3a;background:#1b2029;color:#f8fafc;font-size:20px;font-weight:700;line-height:1;display:flex;align-items:center;justify-content:center;cursor:pointer;transition:all .18s ease}
-.creo-left .creo-inputs.afford-mode .field-btn:hover{background:#2563eb;border-color:#2563eb;color:#fff}
-.creo-left .creo-inputs.afford-mode .field-btn:focus{outline:2px solid #2563eb;outline-offset:2px}
 .creo-left .creo-inputs.afford-mode .field-shell{flex:1;display:flex;align-items:center;gap:8px;background:#1a1f28;border:1px solid #2a2f3a;border-radius:14px;padding:10px 14px}
 .creo-left .creo-inputs.afford-mode .field-prefix,
 .creo-left .creo-inputs.afford-mode .field-suffix{font-size:13px;color:#9ca3af;font-weight:600}
@@ -82,25 +79,16 @@
 
 
 
-.creo-left .creo-inputs.afford-mode .field-stepper{display:flex;flex-direction:column;gap:8px}
-.creo-left .creo-inputs.afford-mode .field-btn{width:38px;height:38px;border-radius:12px;border:1px solid #273248;background:#161f30;color:#f8fafc;display:flex;align-items:center;justify-content:center;cursor:pointer;transition:all .18s ease}
-.creo-left .creo-inputs.afford-mode .field-btn:hover{background:#2563eb;border-color:#2563eb;color:#fff}
-.creo-left .creo-inputs.afford-mode .field-btn:focus{outline:2px solid #2563eb;outline-offset:2px}
-.creo-left .creo-inputs.afford-mode .field-btn svg{width:18px;height:18px;pointer-events:none}
-
 .creo-left .creo-inputs.afford-mode .field-toggle{margin-left:auto;display:inline-flex;align-items:center;gap:0;background:#131b2a;border:1px solid #243149;border-radius:999px;padding:2px}
 .creo-left .creo-inputs.afford-mode .field-toggle button{border:none;background:transparent;color:#90a4d4;font-size:11px;font-weight:800;text-transform:uppercase;letter-spacing:.08em;padding:6px 10px;border-radius:999px;cursor:pointer;transition:all .18s ease}
 .creo-left .creo-inputs.afford-mode .field-toggle button.is-active{background:#facc15;color:#0f172a}
 .creo-left .creo-inputs.afford-mode .field-toggle button:focus{outline:none;box-shadow:0 0 0 2px rgba(250,204,21,.35)}
 
-.creo-left .creo-inputs.afford-mode .field-btn.minus{margin-top:-2px}
-.creo-left .creo-inputs.afford-mode .field-btn.plus{margin-bottom:-2px}
 .creo-subnav{display:grid;grid-template-columns:repeat(auto-fit,minmax(120px,1fr));gap:12px;padding:6px;background:#0d121f;border:1px solid #1c2333;border-radius:14px}
 .creo-subbtn{border:1px solid #243149;background:#131c2c;color:#d1d5f9;border-radius:12px;padding:12px 14px;font-size:12px;font-weight:800;text-transform:uppercase;letter-spacing:.12em;cursor:pointer;transition:all .18s ease;display:flex;align-items:center;justify-content:center}
 .creo-subbtn.is-active{background:#facc15;color:#0f172a;border-color:#facc15;box-shadow:0 8px 18px rgba(250,204,21,.35)}
 .creo-subbtn:hover{border-color:#facc15;color:#facc15}
 
-.creo-left .creo-inputs.afford-mode .field-btn svg{width:18px;height:18px}
 .creo-subnav{display:grid;grid-template-columns:repeat(auto-fit,minmax(120px,1fr));gap:10px}
 .creo-subbtn{border:1px solid #1f2937;background:#111827;color:#e5e7eb;border-radius:999px;padding:10px 14px;font-size:13px;font-weight:700;text-transform:uppercase;letter-spacing:.05em;cursor:pointer;transition:all .18s ease}
 .creo-subbtn.is-active{background:#fbbf24;color:#111827;border-color:#fbbf24}

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -2,11 +2,6 @@
 (function(){
   const config = (typeof window !== 'undefined' && window.CREO_MC) ? window.CREO_MC : {};
   const state = { active:null, tabs: config.tabs || {} };
-  const ICONS = {
-    plus: '<svg aria-hidden="true" viewBox="0 0 24 24"><path d="M12 5v14M5 12h14" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>',
-    minus: '<svg aria-hidden="true" viewBox="0 0 24 24"><path d="M5 12h14" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>'
-  };
-
   // helpers
   function money(v){
     try { return (isFinite(v)?v:0).toLocaleString(undefined,{style:'currency',currency:'USD'}); }
@@ -339,7 +334,6 @@
       let input = null;
       let prefix = null;
       let suffix = null;
-      let stepValue = Number(def.step ?? 1);
       let decimalsUsed = Number.isFinite(def.decimals) ? def.decimals : inferDecimals(def.step || 0);
 
       if (isSelect){
@@ -427,8 +421,8 @@
           const cfg = modes[modeKey] || {};
           const prevMode = currentMode;
           currentMode = modeKey;
-          stepValue = Number(cfg.step ?? def.step ?? 1);
-          input.step = String(stepValue);
+          const stepSetting = Number(cfg.step ?? def.step ?? 1);
+          input.step = String(stepSetting);
           const dec = cfg.decimals;
           const fallbackDec = Number.isFinite(def.decimals) ? def.decimals : inferDecimals(cfg.step ?? def.step ?? 0);
           decimalsUsed = Number.isFinite(dec) ? dec : fallbackDec;
@@ -475,41 +469,6 @@
           input.dataset.mode = '';
         }
 
-        let plusBtn = null;
-        let minusBtn = null;
-        if (def.stepper !== false && !def.readonly){
-          const stepper = document.createElement('div');
-          stepper.className = 'field-stepper';
-          plusBtn = document.createElement('button');
-          plusBtn.type = 'button';
-          plusBtn.className = 'field-btn plus';
-          plusBtn.innerHTML = ICONS.plus;
-          plusBtn.setAttribute('aria-label', `Increase ${def.label}`);
-          stepper.appendChild(plusBtn);
-
-          minusBtn = document.createElement('button');
-          minusBtn.type = 'button';
-          minusBtn.className = 'field-btn minus';
-          minusBtn.innerHTML = ICONS.minus;
-          minusBtn.setAttribute('aria-label', `Decrease ${def.label}`);
-          stepper.appendChild(minusBtn);
-
-          control.appendChild(stepper);
-        }
-
-        function adjust(delta){
-          const current = parseFloat(input.value || 0);
-          const safe = Number.isFinite(current) ? current : 0;
-          let next = safe + (stepValue * delta);
-          if (def.min !== undefined) next = Math.max(def.min, next);
-          if (def.max !== undefined) next = Math.min(def.max, next);
-          input.value = formatValue(next, decimalsUsed);
-          input.dispatchEvent(new Event('input',{bubbles:true}));
-        }
-
-        if (plusBtn) plusBtn.addEventListener('click', () => adjust(1));
-        if (minusBtn) minusBtn.addEventListener('click', () => adjust(-1));
-
         input.addEventListener('focus', () => wrap.classList.add('is-focused'));
         input.addEventListener('blur', () => wrap.classList.remove('is-focused'));
       }
@@ -527,7 +486,7 @@
       {name:'monthly_debts', label:'Monthly Debts', prefix:'$', note:'Per Month', step:50, min:0, decimals:0, default:getValue('monthly_debts', 1500)},
       {name:'home_price', label:'Home Price', prefix:'$', note:'Purchase Price', step:1000, min:0, decimals:0, default:getValue('home_price', 200000)},
       {name:'down_payment', label:'Down Payment', prefix:'$', step:1000, min:0, decimals:0, default:getValue('down_payment', 0), modes:{amount:{label:'$', prefix:'$'}, percent:{label:'%', suffix:'%', decimals:2, step:0.25}}, defaultMode:'amount'},
-      {name:'loan_amount', label:'Loan Amount', note:'Calculated', prefix:'$', step:1000, min:0, decimals:0, default:initialLoan, stepper:false, readonly:true},
+      {name:'loan_amount', label:'Loan Amount', note:'Calculated', prefix:'$', step:1000, min:0, decimals:0, default:initialLoan, readonly:true},
       {name:'loan_terms', label:'Loan Term', step:1, min:1, decimals:0, default:getValue('loan_terms', 30), modes:{years:{label:'Year', suffix:'Years', decimals:0, step:1}, months:{label:'Month', suffix:'Months', decimals:0, step:1}}, defaultMode:'years'},
       {name:'interest_rate', label:'Interest Rate', suffix:'%', step:0.125, min:0, decimals:3, default:getValue('interest_rate', 6.5)},
       {name:'credit_score', label:'Credit Score', type:'select', options:creditChoices.map(value => ({value, label:value})), default:creditDefault},


### PR DESCRIPTION
## Summary
- remove the JavaScript icon constants and stepper button generation from the affordability field builder
- drop the unused CSS selectors that styled the field stepper and plus/minus controls

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cb192a63e8832eae86764e182028d0