### PR TITLE
Sync affordability interest rate with live yearly change data

### DIFF
--- a/includes/class-frontend.php
+++ b/includes/class-frontend.php
@@ -17,10 +17,16 @@ class Creo_MC_Frontend {
     wp_enqueue_style( 'creo-mc-frontend' );
     wp_enqueue_script( 'creo-mc-donut' );
     $tabs = creo_mc_get_tabs();
+    $live = creo_mc_get_live_metrics();
+    $yearly_change = isset( $live['yearly_change'] ) ? $live['yearly_change'] : '';
+
     wp_localize_script( 'creo-mc-frontend', 'CREO_MC', [
-      'tabs'     => $tabs,
-      'restRoot' => esc_url_raw( rest_url( 'creo-mc/v1' ) ),
-      'nonce'    => wp_create_nonce( 'wp_rest' ),
+      'tabs'         => $tabs,
+      'restRoot'     => esc_url_raw( rest_url( 'creo-mc/v1' ) ),
+      'nonce'        => wp_create_nonce( 'wp_rest' ),
+      'live'         => $live,
+      'yearly_change'=> $yearly_change,
+      'yearlyChange' => $yearly_change,
     ] );
     wp_enqueue_script( 'creo-mc-frontend' );
     ob_start();

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -18,6 +18,47 @@ function creo_mc_color( $tabs, $key, $fallback ) {
   return isset( $tabs['_theme'][ $key ] ) ? $tabs['_theme'][ $key ] : $fallback;
 }
 
+function creo_mc_normalize_metric_value( $value ) {
+  if ( is_object( $value ) ) {
+    $value = (array) $value;
+  }
+
+  if ( is_array( $value ) ) {
+    $candidates = [ 'value', 'yearly_change', 'yearlyChange', 'rate', 'amount' ];
+    foreach ( $candidates as $key ) {
+      if ( array_key_exists( $key, $value ) ) {
+        return creo_mc_normalize_metric_value( $value[ $key ] );
+      }
+    }
+    return '';
+  }
+
+  if ( is_numeric( $value ) ) {
+    return 0 + $value;
+  }
+
+  if ( is_string( $value ) ) {
+    return sanitize_text_field( $value );
+  }
+
+  return '';
+}
+
+function creo_mc_get_live_metrics() {
+  $stored  = get_option( 'creo_mc_yearly_change', '' );
+  $payload = [ 'yearly_change' => $stored ];
+
+  $filtered = apply_filters( 'creo_mc_live_metrics', $payload, $stored );
+  if ( is_array( $filtered ) ) {
+    $payload = array_merge( $payload, $filtered );
+  }
+
+  $value = isset( $payload['yearly_change'] ) ? $payload['yearly_change'] : $stored;
+  $payload['yearly_change'] = creo_mc_normalize_metric_value( $value );
+
+  return $payload;
+}
+
 /* central amortization helper used by all calculators */
 if ( ! function_exists( 'creo_amort_payment' ) ) {
   function creo_amort_payment( $principal, $annual_rate, $years ) {


### PR DESCRIPTION
## Summary
- expose the normalized yearly-change metric to frontend scripts via `wp_localize_script`
- add a browser-side store that watches live yearly-change updates and shares helpers on `window.CREO_MC`
- seed the affordability interest-rate input from the live value and resync whenever the feed updates

## Testing
- php -l includes/helpers.php
- php -l includes/class-frontend.php
- node --check assets/js/frontend.js

------
https://chatgpt.com/codex/tasks/task_e_68cb78a15bcc832ea7babc6e7d548ce1