### PR TITLE
Restyle calculator tab navigation

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -6,10 +6,10 @@
   font-family:Inter,system-ui,ui-sans-serif,Segoe UI,Roboto,Arial,sans-serif;
   color:#0f172a;
 }
-.creo-calcs-nav{display:flex;align-items:flex-end;gap:18px;border-bottom:1px solid #e5e7eb;margin-bottom:18px;padding:0 4px;flex-wrap:wrap}
+.creo-calcs-nav{display:flex;align-items:flex-end;gap:18px;border-bottom:1px solid #e5e7eb;margin-bottom:18px;padding:0 4px;flex-wrap:nowrap;overflow-x:auto}
 .creo-nav-btn{
-  display:inline-flex;align-items:center;padding:12px 0;background:none;border:none;border-radius:0;box-shadow:none;
-  font-weight:700;color:#111827;cursor:pointer;border-bottom:3px solid transparent;transition:color .18s ease,border-bottom-color .18s ease
+  display:inline-flex;align-items:center;padding:12px 0;margin:0;background:none;border:none;border-radius:0;box-shadow:none;
+  font-weight:700;color:#475569;cursor:pointer;border-bottom:2px solid transparent;transition:color .18s ease,border-bottom-color .18s ease;flex:0 0 auto;white-space:nowrap
 }
 .creo-nav-btn:hover{color:#0f172a;border-bottom-color:#cbd5f5}
 .creo-nav-btn:focus-visible{outline:2px solid #cbd5f5;outline-offset:2px;color:#0f172a;border-bottom-color:#94a3b8}


### PR DESCRIPTION
## Summary
- update the calculator tab bar so its buttons lay out in a single row without button chrome
- refresh hover, focus, and active underline styles to read as navigation links

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cc3c0f1acc832ea954eb60b1becf5c