### PR TITLE
Rework purchase layout into columnar summary

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -163,12 +163,23 @@
 .row-two{grid-template-columns:1fr 1fr}
 @media (max-width:1100px){.row-one,.row-two{grid-template-columns:1fr}}
 
+.creo-columns{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:20px}
+.creo-column{display:flex;flex-direction:column;gap:20px}
+@media (max-width:1100px){.creo-columns{grid-template-columns:1fr}}
+
 /* cards */
 .creo-card{background:#fff;border:1px solid #e5e7eb;border-radius:14px;padding:16px}
 .creo-card.info-card{background:#f8fafc;border-color:#e2e8f0}
 .creo-card-h{display:flex;align-items:center;justify-content:space-between;margin-bottom:12px}
 .creo-card-h h3{margin:0;font-size:15px}
 .creo-card-copy{margin:0 0 12px;font-size:13px;line-height:1.5;color:#475569}
+
+.creo-card.kpi-card{display:flex;flex-direction:column;gap:14px}
+.creo-card.kpi-card .creo-card-h h3{font-weight:700}
+
+.creo-card.range-card{background:#eff6ff;border-color:#dbeafe;display:flex;flex-direction:column;gap:18px}
+.creo-card.range-card .creo-card-h h3{color:#1d4ed8;font-size:14px;font-weight:700}
+.creo-card.range-card .range-meta span{color:#1e3a8a;font-weight:600}
 
 /* controls card (merged duplicates) */
 .creo-card.controls-card{background:#eff6ff;border-color:#dbeafe}
@@ -187,6 +198,7 @@
 }
 .creo-card.summary-card .creo-summary{font-size:14px;line-height:1.75;color:inherit}
 .creo-card.summary-card .creo-summary strong{color:#fff}
+.creo-columns .creo-card.summary-card{max-width:none}
 .rightcol{display:grid;grid-template-rows:auto auto;gap:20px}
 
 /* Affordability KPIs (use single, final set) */
@@ -256,6 +268,7 @@
 
 /* sliders in right column */
 .range-field{display:flex;flex-direction:column;gap:10px}
+.range-field.no-label .range-h{justify-content:flex-end}
 .range-h{display:flex;align-items:center;justify-content:space-between;font-size:13px;font-weight:600;color:#1f2937}
 .range-value{font-size:18px;font-weight:800;color:#1d4ed8}
 .range input[type=range]{width:100%;appearance:none;background:transparent}

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -916,7 +916,6 @@
     }
 
     function buildRangeControls(homeVal, downVal, opts){
-      const card = createCard(opts?.title || 'Adjust Your Numbers', {cls:'controls-card'});
       const homeMin = 50000;
       const homeMax = 2000000;
       const downFactor = opts?.downMaxFactor ?? 0.5;
@@ -924,61 +923,66 @@
       const downLimit = value => Math.max(0, Math.round(downFactor * value));
       let currentDown = Math.min(Math.max(downVal || 0, 0), downLimit(currentHome));
 
-      const priceField = document.createElement('div');
-      priceField.className = 'range-field';
-      const priceHead = document.createElement('div');
-      priceHead.className = 'range-h';
-      priceHead.innerHTML = '<span>Purchase Price</span>';
-      const priceValue = document.createElement('span');
-      priceValue.className = 'range-value';
-      priceValue.textContent = money(currentHome);
-      priceHead.appendChild(priceValue);
-      const priceWrap = document.createElement('div');
-      priceWrap.className = 'range';
-      const priceInput = document.createElement('input');
-      priceInput.type = 'range';
-      priceInput.min = String(homeMin);
-      priceInput.max = String(homeMax);
-      priceInput.step = '1000';
-      priceInput.name = '_price';
-      priceInput.value = currentHome;
-      priceWrap.appendChild(priceInput);
-      const priceMeta = document.createElement('div');
-      priceMeta.className = 'range-meta';
-      priceMeta.innerHTML = `<span>${money(homeMin)}</span><span>${money(homeMax)}</span>`;
-      priceField.append(priceHead, priceWrap, priceMeta);
+      function makeRangeField(config){
+        const field = document.createElement('div');
+        field.className = 'range-field';
+        if (!config.showLabel) field.classList.add('no-label');
+        const head = document.createElement('div');
+        head.className = 'range-h';
+        if (config.showLabel){
+          const label = document.createElement('span');
+          label.textContent = config.label;
+          head.appendChild(label);
+        }
+        const valueEl = document.createElement('span');
+        valueEl.className = 'range-value';
+        valueEl.textContent = money(config.value);
+        head.appendChild(valueEl);
+        const rangeWrap = document.createElement('div');
+        rangeWrap.className = 'range';
+        const input = document.createElement('input');
+        input.type = 'range';
+        input.min = String(config.min);
+        input.max = String(config.max);
+        input.step = String(config.step ?? 1);
+        if (config.name) input.name = config.name;
+        input.value = String(config.value ?? config.min);
+        rangeWrap.appendChild(input);
+        const meta = document.createElement('div');
+        meta.className = 'range-meta';
+        const minEl = document.createElement('span');
+        minEl.textContent = money(config.min);
+        const maxEl = document.createElement('span');
+        maxEl.textContent = money(config.max);
+        meta.append(minEl, maxEl);
+        field.append(head, rangeWrap, meta);
+        return {field, input, valueEl, minEl, maxEl};
+      }
 
-      const downField = document.createElement('div');
-      downField.className = 'range-field';
-      const downHead = document.createElement('div');
-      downHead.className = 'range-h';
-      downHead.innerHTML = '<span>Down Payment</span>';
-      const downValueEl = document.createElement('span');
-      downValueEl.className = 'range-value';
-      downValueEl.textContent = money(currentDown);
-      downHead.appendChild(downValueEl);
-      const downWrap = document.createElement('div');
-      downWrap.className = 'range';
-      const downInput = document.createElement('input');
-      downInput.type = 'range';
-      downInput.min = '0';
-      downInput.step = '500';
-      downInput.name = '_down';
-      downInput.max = String(downLimit(currentHome));
-      downInput.value = currentDown;
-      downWrap.appendChild(downInput);
-      const downMeta = document.createElement('div');
-      downMeta.className = 'range-meta';
-      downMeta.innerHTML = `<span>${money(0)}</span><span>${money(Number(downInput.max))}</span>`;
-      const downMetaSpans = downMeta.querySelectorAll('span');
-      downField.append(downHead, downWrap, downMeta);
-
-      card.appendChild(priceField);
-      card.appendChild(downField);
+      const showLabels = !opts?.split;
+      const priceField = makeRangeField({
+        label: 'Purchase Price',
+        min: homeMin,
+        max: homeMax,
+        step: 1000,
+        value: currentHome,
+        name: '_price',
+        showLabel: showLabels,
+      });
+      const downField = makeRangeField({
+        label: 'Down Payment',
+        min: 0,
+        max: downLimit(currentHome),
+        step: 500,
+        value: currentDown,
+        name: '_down',
+        showLabel: showLabels,
+      });
 
       const homeFieldEl = opts?.homeField ? form.querySelector(`[name="${opts.homeField}"]`) : null;
       const downFieldEl = opts?.downField ? form.querySelector(`[name="${opts.downField}"]`) : null;
       const loanFieldEl = form.querySelector('[name="loan_amount"]');
+      const baseFieldEl = opts?.baseField ? form.querySelector(`[name="${opts.baseField}"]`) : null;
 
       function updateHomeField(value){
         if (!homeFieldEl) return;
@@ -1000,9 +1004,15 @@
       }
 
       function updateLoanField(homeValue, downAmount){
-        if (!loanFieldEl) return;
-        const decimals = Number(loanFieldEl.dataset.decimals || 0);
-        loanFieldEl.value = formatValue(Math.max(0, homeValue - downAmount), decimals);
+        const amount = Math.max(0, homeValue - downAmount);
+        if (loanFieldEl){
+          const decimals = Number(loanFieldEl.dataset.decimals || 0);
+          loanFieldEl.value = formatValue(amount, decimals);
+        }
+        if (baseFieldEl){
+          const decimals = Number(baseFieldEl.dataset.decimals || 0);
+          baseFieldEl.value = formatValue(amount, decimals);
+        }
       }
 
       function readDownAmount(homeValue){
@@ -1016,22 +1026,26 @@
       updateDownField(currentDown, currentHome);
       updateLoanField(currentHome, currentDown);
 
+      const priceInput = priceField.input;
+      const downInput = downField.input;
+
       priceInput.oninput = debounce(e => {
         const value = Math.min(Math.max(parseFloat(e.target.value || 0) || homeMin, homeMin), homeMax);
         currentHome = value;
-        priceValue.textContent = money(value);
+        priceInput.value = String(value);
+        priceField.valueEl.textContent = money(value);
         updateHomeField(value);
         const newMax = downLimit(value);
         downInput.max = String(newMax);
-        if (downMetaSpans && downMetaSpans[1]) downMetaSpans[1].textContent = money(newMax);
+        if (downField.maxEl) downField.maxEl.textContent = money(newMax);
         let amount = readDownAmount(value);
         if (amount > newMax){
           amount = newMax;
           updateDownField(amount, value);
         }
         currentDown = amount;
-        downInput.value = amount;
-        downValueEl.textContent = money(amount);
+        downInput.value = String(amount);
+        downField.valueEl.textContent = money(amount);
         updateLoanField(value, amount);
         calculate(form, id);
       }, 80);
@@ -1041,12 +1055,22 @@
         const value = Math.min(Math.max(parseFloat(e.target.value || 0) || 0, 0), max);
         currentDown = value;
         const homeValue = currentHome;
-        downValueEl.textContent = money(value);
+        downInput.value = String(value);
+        downField.valueEl.textContent = money(value);
         updateDownField(value, homeValue);
         updateLoanField(homeValue, value);
         calculate(form, id);
       }, 80);
 
+      if (opts?.split){
+        const priceCard = createCard(opts?.priceTitle || 'Purchase Price', {cls:'range-card', body: priceField.field});
+        const downCard = createCard(opts?.downTitle || 'Down Payment', {cls:'range-card', body: downField.field});
+        return {priceCard, downCard};
+      }
+
+      const card = createCard(opts?.title || 'Adjust Your Numbers', {cls:'controls-card'});
+      card.appendChild(priceField.field);
+      card.appendChild(downField.field);
       return card;
     }
 
@@ -1146,7 +1170,7 @@
       const homeVal = byLabel(d?.monthlyBreak, 'home value') ?? Number(form.querySelector('[name="home_value"]')?.value || 200000);
       const downVal = Number(form.querySelector('[name="down_payment"]')?.value || 0);
 
-      const kpis = buildKpiStack([
+      const kpiStack = buildKpiStack([
         {label:'Monthly Mortgage Payment', value: totalMonthly, cls:'kpi-lg kpi-navy'},
         {label:'Total Loan Amount', value: loanVal || d?.kpis?.[1]?.value || 0, cls:'kpi-lg kpi-navy'},
         {label:'Total Interest Paid', value: d?.kpis?.[2]?.value || 0},
@@ -1154,12 +1178,17 @@
       ]);
 
       const donutCard = buildDonutCard(copy.pay_title || 'Payment Breakdown', copy.pay_info || '', d?.donut);
-      setRow('r1', [donutCard, kpis]);
+      const loanDetailsCard = buildListCard('Loan Details', d?.monthlyBreak || []);
 
-      setRow('r2', [
-        buildListCard('Loan Details', d?.monthlyBreak || []),
-        buildRangeControls(homeVal, downVal, {homeField:'home_value', downField:'down_payment', baseField:'base_amount'})
-      ]);
+      const sliderCards = buildRangeControls(homeVal, downVal, {
+        homeField:'home_value',
+        downField:'down_payment',
+        baseField:'base_amount',
+        split:true,
+      });
+      const priceCard = sliderCards && sliderCards.priceCard ? sliderCards.priceCard : null;
+      const downCard = sliderCards && sliderCards.downCard ? sliderCards.downCard : null;
+      const fallbackSlider = (!priceCard && !downCard && sliderCards instanceof HTMLElement) ? sliderCards : null;
 
       const infoCards = [];
       if (copy.early_title || copy.early_info){
@@ -1175,11 +1204,37 @@
           {label:'First Use', raw: d.fee.first ? 'Yes' : 'No'},
         ]));
       }
-      if (infoCards.length) setRow('r3', infoCards);
 
       const dpPct = homeVal > 0 ? (downVal/homeVal) * 100 : 0;
       const summaryText = `Your estimated total monthly payment is <strong>${money(totalMonthly)}</strong> with a loan amount of <strong>${money(loanVal || 0)}</strong> and a down payment of <strong>${money(downVal)} (${dpPct.toFixed(1)}%)</strong>. Review property taxes, insurance and HOA dues for accuracy with your loan officer.`;
-      setRow('r4', [buildSummaryCard(summaryText)]);
+      const summaryCard = buildSummaryCard(summaryText);
+
+      const columns = document.createElement('div');
+      columns.className = 'creo-columns';
+
+      const colOne = document.createElement('div');
+      colOne.className = 'creo-column column-primary';
+      colOne.appendChild(donutCard);
+      colOne.appendChild(loanDetailsCard);
+      infoCards.forEach(card => colOne.appendChild(card));
+
+      const metricsCard = createCard(copy.kpi_title || 'Key Metrics', {cls:'kpi-card', body: kpiStack});
+      const colTwo = document.createElement('div');
+      colTwo.className = 'creo-column column-secondary';
+      colTwo.appendChild(metricsCard);
+      if (priceCard) colTwo.appendChild(priceCard);
+      if (downCard) colTwo.appendChild(downCard);
+      if (!priceCard && !downCard && fallbackSlider) colTwo.appendChild(fallbackSlider);
+      colTwo.appendChild(summaryCard);
+
+      columns.append(colOne, colTwo);
+
+      setRow('r1', [columns]);
+      setRow('r2', []);
+      setRow('r3', []);
+      setRow('r4', []);
+      setRow('r5', []);
+      setRow('r6', []);
       return;
     }
 


### PR DESCRIPTION
## Summary
- restructure the purchase calculator results pane into a two-column layout grouping the payment breakdown, loan details, KPIs, sliders, and summary
- enhance the shared range control builder to support split slider cards while keeping form fields in sync
- add styling for the new column layout and slider cards so the updated structure renders correctly

## Testing
- Not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cc726a79dc832e8f035ef5708e414b